### PR TITLE
the score/kill loops assumed 10 players; fixed

### DIFF
--- a/src/classes/web.js
+++ b/src/classes/web.js
@@ -93,7 +93,7 @@ class Web {
      */
     async ApiOverviewRoute(req, res) {
         const data = await global.models.Player.findAll({
-            attributes: ['id', 'name', 'score', 'kills', 'deaths', 'headshots', 'steam'],
+            attributes: ['id', 'name', 'score', 'kills', 'deaths', 'headshots', 'steam', 'hits', 'shots' ],
             limit: 1000,
             order: [
                 ['score', 'DESC']

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -72,7 +72,7 @@ $(document).ready(async () => {
     const topScoreNames = [];
     const topScoreData = [];
 
-    for (let index = 0; index < 10; index++) {
+    for (let index = 0; index < Math.min(10, sortedByScore.length); index++) {
         const runnerUpPlayer = _.find(playerData, {
             steam: sortedByScore[index].steamId
         });
@@ -81,7 +81,7 @@ $(document).ready(async () => {
         $("#score-inc ol").append(`<li><a href="/player/${runnerUpPlayer.id}"><span class="tab">${runnerUpPlayer.name}</span></a> +${sortedByScore[index].scoreDifference} </li>`);
     }
 
-    for (let index = 0; index < 10; index++) {
+    for (let index = 0; index < Math.min(10, sortedByKills.length); index++) {
         const runnerUpPlayer = _.find(playerData, {
             steam: sortedByKills[index].steamId
         });

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -27,6 +27,12 @@ $(document).ready(async () => {
             },
             {
                 data: 'deaths'
+            }, {
+                render: function (data, type, row, meta) {
+                    let accuracy = (row.hits / (parseInt(row.shots) + 1) * 100);
+                    accuracy = accuracy.toFixed(0);
+                    return accuracy + " %";
+                }
             }
         ]
     });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -66,6 +66,7 @@
                                 <th>Headshot %</th>
                                 <th>Kills</th>
                                 <th>Deaths</th>
+                                <th>Accuracy</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Graphs would bork out if there are stats for fewer than 10 players.  